### PR TITLE
typo on Usage: cycle

### DIFF
--- a/bin/dynamic-colors
+++ b/bin/dynamic-colors
@@ -7,7 +7,7 @@ dynamic-colors <command>
 
 Basic commands:
   h,help                  print this help message
-  c,ycle                  cycle through color schemes
+  c,cycle                  cycle through color schemes
   e,edit [<colorscheme>]  edit <colorscheme> when given or launch editor
                           in colorschemes directory otherwise
   i,init                  (re)load last color scheme


### PR DESCRIPTION
fixed `cycle` in usage string to match convention with all other commands (repeat first letter on long option)
