### PR TITLE
Check $string in on_user_command() to avoid activation via other keybindings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Add this to ~/.Xdefaults:
 
     urxvt*perl-ext-common: urxvt-colors
     urxvt*perl-lib: [directoy of urxvt-colors]
-    urxvt*keysym.F12: perl:urxvt-colors:
+    urxvt*keysym.F12: perl:urxvt-colors:cycle
 
 Now you can cycle through all color schemes using F12 for example,
 without closing running console applications.


### PR DESCRIPTION
Hi,

Fix a bug when using the extension snippet provided: `dynamic-color cycle` was called every time using another extension key-binding (eg: copy/paste).

disclaimer: I'm not a perl programmer, I looked at the default extensions in `/usr/lib/urxvt/perl/` which implement this kind of check.
