### PR TITLE
Separate config and automatically find root path

### DIFF
--- a/bin/dynamic-colors
+++ b/bin/dynamic-colors
@@ -84,16 +84,27 @@ else
 fi
 COLORSCHEMES="${DYNAMIC_COLORS_ROOT}/colorschemes"
 
+if [ -z "${DYNAMIC_COLORS_HOME}" ]; then
+  if [ -d "${HOME}/.dynamic-colors" ] || [ -z "${XDG_CONFIG_HOME}" ]; then
+    DYNAMIC_COLORS_HOME="${HOME}/.dynamic-colors"
+  else
+    DYNAMIC_COLORS_HOME="${XDG_CONFIG_HOME}/dynamic-colors"
+  fi
+else
+  DYNAMIC_COLORS_HOME="${DYNAMIC_COLORS_HOME%/}"
+fi
+
 write_colorscheme_name () {
-  echo "$1" > "${DYNAMIC_COLORS_ROOT}/colorscheme"
+  [ ! -d "${DYNAMIC_COLORS_HOME}" ] && mkdir -p "${DYNAMIC_COLORS_HOME}"
+  echo "$1" > "${DYNAMIC_COLORS_HOME}/colorscheme"
 }
 
 load_colorscheme_name () {
-  head -1 "${DYNAMIC_COLORS_ROOT}/colorscheme"
+  head -1 "${DYNAMIC_COLORS_HOME}/colorscheme"
 }
 
 init () {
-  [ ! -f "${DYNAMIC_COLORS_ROOT}/colorscheme" ] && return
+  [ ! -f "${DYNAMIC_COLORS_HOME}/colorscheme" ] && return
   colorscheme_name=$(load_colorscheme_name)
   load_colorscheme "$colorscheme_name"
   set_colors
@@ -142,8 +153,8 @@ audit () {
 }
 
 cycle() {
-    if [ -f "${DYNAMIC_COLORS_ROOT}/colorscheme" ]; then
-        current=`head -1 "${DYNAMIC_COLORS_ROOT}/colorscheme"`
+    if [ -f "${DYNAMIC_COLORS_HOME}/colorscheme" ]; then
+        current=$(load_colorscheme_name)
         found=false
         cd "$COLORSCHEMES"
         for file in *.sh; do

--- a/bin/dynamic-colors
+++ b/bin/dynamic-colors
@@ -69,8 +69,16 @@ OSC="${ESC}]"
 colors=( background foreground cursor mouse_background mouse_foreground highlight border color0 color1 color2 color3 color4 color5 color6 color7 color8 color9 color10 color11 color12 color13 color14 color15 )
 color_names=( black red green yellow blue magenta cyan white brblack brred brgreen bryellow brblue brmagenta brcyan brwhite )
 
+script_root () {
+  script_dir=$(cd "$(dirname "$0")"; pwd)
+  if [ -h "$0" ]; then
+    script_dir=$(dirname "$(readlink "$0")" 2>/dev/null)
+  fi
+  echo ${script_dir%/bin}
+}
+
 if [ -z "${DYNAMIC_COLORS_ROOT}" ]; then
-  DYNAMIC_COLORS_ROOT="${HOME}/.dynamic-colors"
+  DYNAMIC_COLORS_ROOT="$(script_root)"
 else
   DYNAMIC_COLORS_ROOT="${DYNAMIC_COLORS_ROOT%/}"
 fi


### PR DESCRIPTION
Hi Stefan,

this adds automatic root path resolution. I wanted to symlink the script to my local `bin` directory instead of modifying `PATH`. Could have set the environment variable instead, but I figured it would be nice if the script would autolocate its data.

The second patch separates the configuration (i.e. the `colorscheme` file :) from the code, storing it at `XDG_CONFIG_HOME` or below `HOME`, if that is not available.

Cheers
malte