### PR TITLE
Readme updated with a less conflicting urxvt script

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,9 @@ Save this to a file named "urxvt-colors":
       my ($self, $cmd) = @_;
       my $output = `dynamic-colors cycle`;
 
-		  if ($cmd eq 'urxvt-colors:cycle') {
-        $self->cmd_parse($output);
-		  }
+	if ($cmd eq 'urxvt-colors:cycle') {
+		$self->cmd_parse($output);
+	}
     }
 
 Add this to ~/.Xdefaults:

--- a/README.md
+++ b/README.md
@@ -75,16 +75,19 @@ Check if all colors are defined:
 Save this to a file named "urxvt-colors":
 
     sub on_user_command {
-        my ($self, $cmd) = @_;
-        my $output = `dynamic-colors cycle`;
+      my ($self, $cmd) = @_;
+      my $output = `dynamic-colors cycle`;
+
+		  if ($cmd eq 'urxvt-colors:cycle') {
         $self->cmd_parse($output);
+		  }
     }
 
 Add this to ~/.Xdefaults:
 
     urxvt*perl-ext-common: urxvt-colors
     urxvt*perl-lib: [directoy of urxvt-colors]
-    urxvt*keysym.F12: perl:urxvt-colors:
+    urxvt*keysym.F12: perl:urxvt-colors:cycle
 
 Now you can cycle through all color schemes using F12 for example,
 without closing running console applications.


### PR DESCRIPTION
I ran into trouble when having the following scripts in my urxvt config:
``*URxvt.perl-ext-common:  default,matcher,font-size,vtwheel,keyboard-select,clipboard,urxvt-colors-switch``

I know nothing about perl, but when I activated any of my other plugins, cycle-colors fired too. Upon inspection, I saw that other plugins share the following structure:
````
if ($cmd eq '**command_name**') {
    **execute the action**
}
````
This solved my issue. 
