### PR TITLE
Feature/override root directory

### DIFF
--- a/bin/dynamic-colors
+++ b/bin/dynamic-colors
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 USAGE="Usage: dynamic-colors [help|cycle|init|list|switch <colorscheme>]"

--- a/bin/dynamic-colors
+++ b/bin/dynamic-colors
@@ -69,6 +69,23 @@ OSC="${ESC}]"
 colors=( background foreground cursor mouse_background mouse_foreground highlight border color0 color1 color2 color3 color4 color5 color6 color7 color8 color9 color10 color11 color12 color13 color14 color15 )
 color_names=( black red green yellow blue magenta cyan white brblack brred brgreen bryellow brblue brmagenta brcyan brwhite )
 
+while getopts ":o:" opt; do
+  case $opt in
+    o)
+      DYNAMIC_COLORS_ROOT="${OPTARG%/}"
+      shift; shift;
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      exit 1
+      ;;
+    :)
+      echo "Option -$OPTARG requires path to a dynamic-color folder" >&2
+      exit 1
+      ;;
+  esac
+done
+
 if [ -z "${DYNAMIC_COLORS_ROOT}" ]; then
   DYNAMIC_COLORS_ROOT="${HOME}/.dynamic-colors"
 else

--- a/bin/dynamic-colors
+++ b/bin/dynamic-colors
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
 set -e
 
-USAGE="Usage: dynamic-colors [help|cycle|init|list|switch <colorscheme>]"
+USAGE="Usage: dynamic-colors [-o <path>] [help|cycle|init|list|switch <colorscheme>]"
 HELP="\
 dynamic-colors <command>
+
+Option:
+  -o <path>               override root directory
 
 Basic commands:
   h,help                  print this help message


### PR DESCRIPTION
This is usefull for some systems like `NixOS`, where you can install `dynamic-colors` directly in the system [https://github.com/NixOS/nixpkgs/blob/9cb194cfa449c43f63185a25c8d10307aea3b358/pkgs/tools/misc/dynamic-colors/default.nix#L34](url), because then we cannot change or add new color theme, since we don't have the rights to change system files.
