### PR TITLE
Set border to background by default

### DIFF
--- a/bin/dynamic-colors
+++ b/bin/dynamic-colors
@@ -31,7 +31,9 @@ change_color () {
   foreground)
     send_osc 10 "$2" ;;
   background)
-    send_osc 11 "$2" ;;
+    send_osc 11 "$2"
+    send_osc 708 "$2"
+    ;;
   cursor)
     send_osc 12 "$2" ;;
   mouse_foreground)


### PR DESCRIPTION
When the inner border color is not defined, it stays the same color as set by Xdefaults when switching themes. Most of the themes don't define it, so it doesn't leave good impression..

This PR fixes that. Similarly to Xdefaults, it sets the border color to background color, unless it's overriden by border property explicitely.