### PR TITLE
added base4 to change auto-complete color

### DIFF
--- a/colorschemes/solarized-light.sh
+++ b/colorschemes/solarized-light.sh
@@ -11,9 +11,9 @@
  base00="#657b83"  # base00    #657b83 11/7 bryellow  50 -07 -07
   base0="#839496"  # base0     #839496 12/6 brblue    60 -06 -03
   base1="#93a1a1"  # base1     #93a1a1 14/4 brcyan    65 -05 -02
-  base2="#eee8d5"  # base2     #eee8d5  7/7 white     92 -00  10
-  base3="#95a1a1"  # base4     #95a1a1 15/8 lightgray 65.28 -4.41 -1.54
-  base4="#fdf6e3"  # base3     #fdf6e3 15/7 brwhite   97  00  10
+  base2="#eee8d5"  # base2     #eee8d5  7/7 warmwhite 92 -00  10
+  base3="#95a1a1"  # base3     #95a1a1 15/8 lightgray 65.28 -4.41 -1.54
+  base4="#fdf6e3"  # base4     #fdf6e3 15/7 brwhite   97  00  10
  yellow="#b58900"  # yellow    #b58900  3/3 yellow    60  10  65
  orange="#cb4b16"  # orange    #cb4b16  9/3 brred     50  50  55
     red="#dc322f"  # red       #dc322f  1/1 red       50  65  45

--- a/colorschemes/solarized-light.sh
+++ b/colorschemes/solarized-light.sh
@@ -12,7 +12,8 @@
   base0="#839496"  # base0     #839496 12/6 brblue    60 -06 -03
   base1="#93a1a1"  # base1     #93a1a1 14/4 brcyan    65 -05 -02
   base2="#eee8d5"  # base2     #eee8d5  7/7 white     92 -00  10
-  base3="#fdf6e3"  # base3     #fdf6e3 15/7 brwhite   97  00  10
+  base3="#95a1a1"  # base4     #95a1a1 15/8 lightgray 65.28 -4.41 -1.54
+  base4="#fdf6e3"  # base3     #fdf6e3 15/7 brwhite   97  00  10
  yellow="#b58900"  # yellow    #b58900  3/3 yellow    60  10  65
  orange="#cb4b16"  # orange    #cb4b16  9/3 brred     50  50  55
     red="#dc322f"  # red       #dc322f  1/1 red       50  65  45
@@ -22,13 +23,13 @@ magenta="#d33682"  # magenta   #d33682  5/5 magenta   50  65 -05
    cyan="#2aa198"  # cyan      #2aa198  6/6 cyan      60 -35 -05
   green="#859900"  # green     #859900  2/2 green     60 -20  65
 
-background="$base3"
+background="$base4"
 foreground="$base00"
 cursor="$base01"
 mouse_background="$base2"
 mouse_foreground="$base01"
 highlight="$base2"
-border="$base3"
+border="$base4"
 
  color0="$base2"   # black
  color8="$base3"   # brblack


### PR DESCRIPTION
Added base4 to solarized-light 
Set background and border to base4 and the auto-complete to base3 (light gray) to be able to see auto-complete suggestions.