### PR TITLE
fix: tmux `allow-passthrough` is off by default

### DIFF
--- a/bin/dynamic-colors
+++ b/bin/dynamic-colors
@@ -49,7 +49,10 @@ send_escape_sequence () {
   escape_sequence="$1"
 
   # wrap escape sequence when within a TMUX session
-  [ ! -z "$TMUX" ] && escape_sequence="${DSC}tmux;${ESC}${escape_sequence}${ESC}\\"
+  tmux_allow_passthrough=`tmux show-options -gw 2>/dev/null | awk '$1 == "allow-passthrough" { print $2}'`
+  if [ $tmux_allow_passthrough == on ]; then
+    escape_sequence="${DSC}tmux;${ESC}${escape_sequence}${ESC}\\"
+  fi
 
   printf "${escape_sequence}"
 }


### PR DESCRIPTION
As of tmux 3.3a, the `allow-passthrough` option is off by default. Further, as mentioned in https://github.com/tmux/tmux/wiki/FAQ:
```
The passthrough escape sequence is no longer necessary for changing the
cursor colour or style as tmux now has its own support (see the Cs, Cr,
Ss and Se capabilities).
```

This commit checks whether the `allow-passthrough` is set, and uses it; otherwise, no wrapping is performed.